### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 sudo: required
 language: python
-dist: xenial
+dist: focal
 python:
   - 2.7
-  - 3.4
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
   - "nightly"
   - "pypy"
   - "pypy3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-argon2_cffi>=19.1.0
-Flask>=1.0.3
+argon2_cffi>=20.1.0
+Flask>=1.*


### PR DESCRIPTION
- Update `argon2_cffi` to 20.1.0
- Change `Flask` version to any > 1
- Update travis to test on Ubuntu 20.04
- Drop support for python 3.4 because it's not supported by `argon2_cffi`
