### PR TITLE
Release 0.2.0.0

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,7 +32,7 @@ The following Flask Configs are automatically used by `init_app()`:
 |`ARGON2_HASH_LENGTH`|Length of the hash in bytes.|
 |`ARGON2_SALT_LENGTH`|Length of random salt to be generated for each password.|
 |`ARGON2_ENCODING`|The Argon2 C library expects bytes. So if hash() or verify() are passed an unicode string, it will be encoded using this encoding.|
-The default values are the same than for the [argon2_cffi Libary](https://argon2-cffi.readthedocs.io/en/stable/api.html#argon2.PasswordHasher).
+The default values are the same as the [argon2_cffi library](https://argon2-cffi.readthedocs.io/en/stable/api.html#argon2.PasswordHasher).
 
 Two primary methods are now exposed by way of the argon2 object. Use
 them like so:

--- a/flask_argon2.py
+++ b/flask_argon2.py
@@ -12,11 +12,11 @@ from __future__ import absolute_import
 from __future__ import print_function
 # from sys import version_info
 
-__version_info__ = ('0', '1', '5', '1')
+__version_info__ = ('0', '2', '0', '0')
 __version__ = '.'.join(__version_info__)
-__author__ = 'DominusTemporis'
+__author__ = 'red-coracle'
 __license__ = 'MIT'
-__copyright__ = 'Copyright (c) 2019 DominusTemporis'
+__copyright__ = 'Copyright (c) 2020 red-coracle'
 __all__ = ['Argon2', 'generate_password_hash', 'check_password_hash']
 
 try:


### PR DESCRIPTION
* Update `argon2_cffi` to 20.1.0
* Drop support for python 3.4 because it's not supported by `argon2_cffi`
* Change `Flask` version to any > 1
* Update travis to test on Ubuntu 20.04